### PR TITLE
compat MIPS32 without FPU, Enable static build by default

### DIFF
--- a/buildAll.sh
+++ b/buildAll.sh
@@ -10,22 +10,22 @@ then
     rm binary.tgz
 fi
 
-GOOS=linux GOARCH=amd64 go build -o binary/mr2 .
-GOOS=linux GOARCH=386 go build -o binary/mr2_linux_386 .
-GOOS=linux GOARCH=arm64 go build -o binary/mr2_linux_arm64 .
-GOOS=linux GOARCH=arm GOARM=7 go build -o binary/mr2_linux_arm7 .
-GOOS=linux GOARCH=arm GOARM=6 go build -o binary/mr2_linux_arm6 .
-GOOS=linux GOARCH=arm GOARM=5 go build -o binary/mr2_linux_arm5 .
-GOOS=linux GOARCH=mips go build -o binary/mr2_linux_mips .
-GOOS=linux GOARCH=mips GOMIPS=softfloat go build -o binary/mr2_linux_mips_sf .
-GOOS=linux GOARCH=mipsle go build -o binary/mr2_linux_mipsle .
-GOOS=linux GOARCH=mipsle GOMIPS=softfloat go build -o binary/mr2_linux_mipsle_sf .
-GOOS=linux GOARCH=mips64 go build -o binary/mr2_linux_mips64 .
-GOOS=linux GOARCH=mips64le go build -o binary/mr2_linux_mips64le .
-GOOS=linux GOARCH=ppc64 go build -o binary/mr2_linux_ppc64 .
-GOOS=linux GOARCH=ppc64le go build -o binary/mr2_linux_ppc64le .
-GOOS=darwin GOARCH=amd64 go build -o binary/mr2_darwin_amd64 .
-GOOS=windows GOARCH=amd64 go build -o binary/mr2_windows_amd64.exe .
-GOOS=windows GOARCH=386 go build -o binary/mr2_windows_386.exe .
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o binary/mr2 .
+CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -o binary/mr2_linux_386 .
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o binary/mr2_linux_arm64 .
+CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -o binary/mr2_linux_arm7 .
+CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -o binary/mr2_linux_arm6 .
+CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=5 go build -o binary/mr2_linux_arm5 .
+CGO_ENABLED=0 GOOS=linux GOARCH=mips go build -o binary/mr2_linux_mips .
+CGO_ENABLED=0 GOOS=linux GOARCH=mips GOMIPS=softfloat go build -o binary/mr2_linux_mips_sf .
+CGO_ENABLED=0 GOOS=linux GOARCH=mipsle go build -o binary/mr2_linux_mipsle .
+CGO_ENABLED=0 GOOS=linux GOARCH=mipsle GOMIPS=softfloat go build -o binary/mr2_linux_mipsle_sf .
+CGO_ENABLED=0 GOOS=linux GOARCH=mips64 go build -o binary/mr2_linux_mips64 .
+CGO_ENABLED=0 GOOS=linux GOARCH=mips64le go build -o binary/mr2_linux_mips64le .
+CGO_ENABLED=0 GOOS=linux GOARCH=ppc64 go build -o binary/mr2_linux_ppc64 .
+CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -o binary/mr2_linux_ppc64le .
+CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o binary/mr2_darwin_amd64 .
+CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o binary/mr2_windows_amd64.exe .
+CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -o binary/mr2_windows_386.exe .
 
 tar zcf binary.tgz binary

--- a/buildAll.sh
+++ b/buildAll.sh
@@ -17,7 +17,9 @@ GOOS=linux GOARCH=arm GOARM=7 go build -o binary/mr2_linux_arm7 .
 GOOS=linux GOARCH=arm GOARM=6 go build -o binary/mr2_linux_arm6 .
 GOOS=linux GOARCH=arm GOARM=5 go build -o binary/mr2_linux_arm5 .
 GOOS=linux GOARCH=mips go build -o binary/mr2_linux_mips .
+GOOS=linux GOARCH=mips GOMIPS=softfloat go build -o binary/mr2_linux_mips_sf .
 GOOS=linux GOARCH=mipsle go build -o binary/mr2_linux_mipsle .
+GOOS=linux GOARCH=mipsle GOMIPS=softfloat go build -o binary/mr2_linux_mipsle_sf .
 GOOS=linux GOARCH=mips64 go build -o binary/mr2_linux_mips64 .
 GOOS=linux GOARCH=mips64le go build -o binary/mr2_linux_mips64le .
 GOOS=linux GOARCH=ppc64 go build -o binary/mr2_linux_ppc64 .


### PR DESCRIPTION
Fixes #6 #9.

Changes proposed in this pull request:
- Build with args: `GOMIPS=softfloat`

